### PR TITLE
test: rename assertion methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,11 +90,11 @@ module.exports = class BemEntity {
     valueOf()  { return this._obj; }
 
     /**
-     * Determines whether specified entity is the same entity.
+     * Determines whether specified entity is the deepEqual entity.
      *
      * @param {object} entity - the entity to compare.
      *
-     * @returns {boolean} A Boolean indicating whether or not specified entity is the same entity.
+     * @returns {boolean} A Boolean indicating whether or not specified entity is the deepEqual entity.
      */
     is(entity) {
         return entity && (this.id === entity.id);

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -17,5 +17,5 @@ test('should provide `elem` field', t => {
 test('should provide `mod` field', t => {
     const entity = new BemEntity({ block: 'block', mod: { name: 'mod', val: 'val' } });
 
-    t.same(entity.mod, { name: 'mod', val: 'val' });
+    t.deepEqual(entity.mod, { name: 'mod', val: 'val' });
 });

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -17,7 +17,7 @@ test('should normalize short entry for boolean modifier', t => {
 test('should support `modName` and `modVal` fields', t => {
     const entity = new BemEntity({ block: 'block', modName: 'mod', modVal: 'val' });
 
-    t.same(entity.mod, { name: 'mod', val: 'val' });
+    t.deepEqual(entity.mod, { name: 'mod', val: 'val' });
 });
 
 test('should use `mod.name` field instead of `modName`', t => {

--- a/test/to-string.test.js
+++ b/test/to-string.test.js
@@ -14,7 +14,7 @@ test('should use `naming.stringify()` for block', t => {
 
     entity.toString();
 
-    t.ok(spy.calledWith({ block: 'block' }));
+    t.truthy(spy.calledWith({ block: 'block' }));
 });
 
 test('should use `naming.stringify()` for elem', t => {
@@ -22,7 +22,7 @@ test('should use `naming.stringify()` for elem', t => {
 
     entity.toString();
 
-    t.ok(spy.calledWith({ block: 'block', elem: 'elem' }));
+    t.truthy(spy.calledWith({ block: 'block', elem: 'elem' }));
 });
 
 test('should use `naming.stringify()` for block modifier', t => {
@@ -30,7 +30,7 @@ test('should use `naming.stringify()` for block modifier', t => {
 
     entity.toString();
 
-    t.ok(spy.calledWith({ block: 'block', modName: 'mod', modVal: 'val' }));
+    t.truthy(spy.calledWith({ block: 'block', modName: 'mod', modVal: 'val' }));
 });
 
 test('should use naming.stringify() for element modifier', t => {
@@ -38,5 +38,5 @@ test('should use naming.stringify() for element modifier', t => {
 
     entity.toString();
 
-    t.ok(spy.calledWith({ block: 'block', elem: 'elem', modName: 'mod', modVal: 'val' }));
+    t.truthy(spy.calledWith({ block: 'block', elem: 'elem', modName: 'mod', modVal: 'val' }));
 });

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -15,7 +15,7 @@ test('should use `naming.typeOf()` for block', t => {
     /*eslint no-unused-expressions: "off"*/
     entity.type;
 
-    t.ok(spy.calledWith({ block: 'block' }));
+    t.truthy(spy.calledWith({ block: 'block' }));
 });
 
 test('should use `naming.typeOf()` for elem', t => {
@@ -24,7 +24,7 @@ test('should use `naming.typeOf()` for elem', t => {
     /*eslint no-unused-expressions: "off"*/
     entity.type;
 
-    t.ok(spy.calledWith({ block: 'block', elem: 'elem' }));
+    t.truthy(spy.calledWith({ block: 'block', elem: 'elem' }));
 });
 
 test('should use `naming.typeOf()` for block modifier', t => {
@@ -33,7 +33,7 @@ test('should use `naming.typeOf()` for block modifier', t => {
     /*eslint no-unused-expressions: "off"*/
     entity.type;
 
-    t.ok(spy.calledWith({ block: 'block', modName: 'mod', modVal: 'val' }));
+    t.truthy(spy.calledWith({ block: 'block', modName: 'mod', modVal: 'val' }));
 });
 
 test('should use naming.typeOf() for element modifier', t => {
@@ -42,5 +42,5 @@ test('should use naming.typeOf() for element modifier', t => {
     /*eslint no-unused-expressions: "off"*/
     entity.type;
 
-    t.ok(spy.calledWith({ block: 'block', elem: 'elem', modName: 'mod', modVal: 'val' }));
+    t.truthy(spy.calledWith({ block: 'block', elem: 'elem', modName: 'mod', modVal: 'val' }));
 });

--- a/test/value-of.test.js
+++ b/test/value-of.test.js
@@ -6,5 +6,5 @@ test('should return entity object', t => {
     const obj = { block: 'block' };
     const entity = new BemEntity(obj);
 
-    t.same(entity.valueOf(), obj);
+    t.deepEqual(entity.valueOf(), obj);
 });


### PR DESCRIPTION
The `t.same()` and `t.ok()` methods have been deprecated.